### PR TITLE
placing and removing queens from board

### DIFF
--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -41,58 +41,148 @@ class EightQueens():
         row, column = position
         self._board[row][column]["id"] = "q"
 
+        def tile_is_empty(row: int, column: int) -> bool:
+            "helper subfunction to avoid replacing a queen's id with a killzone from other queens"
+            return self._board[row][column]["id"] != "q"
+
         # row and column killzone
         for i in range(self.size):
             # rows
             placed_queen = column
             if i != placed_queen:
-                self._board[row][i]["id"] = "k"
                 self._board[row][i]["value"] += 1
-                self._board[row][i]["asset"] = self._killzone_asset
+
+                if tile_is_empty(row, i):
+                    self._board[row][i]["id"] = "k"
+                    self._board[row][i]["asset"] = self._killzone_asset
 
             # columns
             placed_queen = row
             if i != placed_queen:
-                self._board[i][column]["id"] = "k"
                 self._board[i][column]["value"] += 1
-                self._board[i][column]["asset"] = self._killzone_asset
+
+                if tile_is_empty(i, column):
+                    self._board[i][column]["id"] = "k"
+                    self._board[i][column]["asset"] = self._killzone_asset
         
         # quadrant 1 (upper right)
         i=1
         while row-i>=0 and column+i<self.size:
-            self._board[row-i][column+i]["id"] = "k"
             self._board[row-i][column+i]["value"] += 1
-            self._board[row-i][column+i]["asset"] = self._killzone_asset
+
+            if tile_is_empty(row-i, column+i):
+                self._board[row-i][column+i]["id"] = "k"
+                self._board[row-i][column+i]["asset"] = self._killzone_asset
             i += 1
 
         # quadrant 2 (upper left)
         i=1
         while row-i>=0 and column-i>=0:
-            self._board[row-i][column-i]["id"] = "k"
             self._board[row-i][column-i]["value"] += 1
-            self._board[row-i][column-i]["asset"] = self._killzone_asset
+
+            if tile_is_empty(row-i, column-i):
+                self._board[row-i][column-i]["id"] = "k"    
+                self._board[row-i][column-i]["asset"] = self._killzone_asset
             i += 1
 
         # quadrant 3 (bottom right)
         i=1
         while row+i<self.size and column-i>=0:
-            self._board[row+i][column-i]["id"] = "k"
             self._board[row+i][column-i]["value"] += 1
-            self._board[row+i][column-i]["asset"] = self._killzone_asset
+
+            if tile_is_empty(row+i, column-i):
+                self._board[row+i][column-i]["id"] = "k"
+                self._board[row+i][column-i]["asset"] = self._killzone_asset
             i += 1
 
         # quadrant 4 (bottom left)
         i=1
         while row+i<self.size and column+i<self.size:
-            self._board[row+i][column+i]["id"] = "k"
             self._board[row+i][column+i]["value"] += 1
-            self._board[row+i][column+i]["asset"] = self._killzone_asset
+
+            if tile_is_empty(row+i, column+i):
+                self._board[row+i][column+i]["id"] = "k"
+                self._board[row+i][column+i]["asset"] = self._killzone_asset
             i += 1
 
         self._validate_queens()
 
     def remove_queen(self, position: tuple):
         self._validate_position(position)
+        self._queen_positions.pop(self._queen_positions.index(position))
+
+        row, column = position
+        self._board[row][column]["id"] = None
+
+        removed_queen_was_killzone = self._board[row][column]["value"] > 0
+        if removed_queen_was_killzone:
+            self._board[row][column]["id"] = "k"
+
+        def removed_killzone_is_empty(row: int, column: int) -> bool:
+            'helper subfunction to avoid replacing asset of an invalid queen when removing a killzone'
+            return self._board[row][column]["value"] == 0 and self._board[row][column]["asset"] == self._killzone_asset
+
+        # row and column killzone
+        for i in range(self.size):
+            # rows
+            removed_queen = column
+            if i != removed_queen:
+                self._board[row][i]["value"] -= 1
+
+                if removed_killzone_is_empty(row, i):
+                    self._board[row][i]["id"] = None
+                    self._board[row][i]["asset"] = None
+
+            # columns
+            removed_queen = row
+            if i != removed_queen:
+                self._board[i][column]["value"] -= 1
+
+                if removed_killzone_is_empty(i,column):
+                    self._board[i][column]["id"] = None
+                    self._board[i][column]["asset"] = None
+        
+        # quadrant 1 (upper right)
+        i=1
+        while row-i>=0 and column+i<self.size:
+            self._board[row-i][column+i]["value"] -= 1
+
+            if removed_killzone_is_empty(row-i, column+i):
+                self._board[row-i][column+i]["id"] = None
+                self._board[row-i][column+i]["asset"] = None
+            i += 1
+
+        # quadrant 2 (upper left)
+        i=1
+        while row-i>=0 and column-i>=0:
+            self._board[row-i][column-i]["value"] -= 1
+            
+            if removed_killzone_is_empty(row-i, column-i):
+                self._board[row-i][column-i]["id"] = None
+                self._board[row-i][column-i]["asset"] = None
+            i += 1
+
+        # quadrant 3 (bottom right)
+        i=1
+        while row+i<self.size and column-i>=0:
+            self._board[row+i][column-i]["value"] -= 1
+            
+            if removed_killzone_is_empty(row+i, column-i):
+                self._board[row+i][column-i]["id"] = None
+                self._board[row+i][column-i]["asset"] = None
+            i += 1
+
+        # quadrant 4 (bottom left)
+        i=1
+        while row+i<self.size and column+i<self.size:
+            self._board[row+i][column+i]["value"] -= 1
+            
+            if removed_killzone_is_empty(row+i, column+i):
+                self._board[row+i][column+i]["id"] = None
+                self._board[row+i][column+i]["asset"] = None
+            i += 1
+
+        self._validate_queens()
 
     def generate_answers(self):
         pass
@@ -103,7 +193,7 @@ class EightQueens():
     def file_to_board(self, file: Path):
         pass
 
-    def _generate_board():
+    def _generate_board(self):
         'description'
         pass
     

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -39,11 +39,11 @@ class EightQueens():
         self._queen_positions.append(position)
 
         row, column = position
-        self._board[row][column]["id"] = "q"
+        self._board[row][column]["id"] = "queen"
 
         def tile_is_empty(row: int, column: int) -> bool:
             "helper subfunction to avoid replacing a queen's id with a killzone from other queens"
-            return self._board[row][column]["id"] != "q"
+            return self._board[row][column]["id"] != "queen"
 
         # row and column killzone
         for i in range(self.size):
@@ -53,7 +53,7 @@ class EightQueens():
                 self._board[row][i]["value"] += 1
 
                 if tile_is_empty(row, i):
-                    self._board[row][i]["id"] = "k"
+                    self._board[row][i]["id"] = "killzone"
                     self._board[row][i]["asset"] = self._killzone_asset
 
             # columns
@@ -62,7 +62,7 @@ class EightQueens():
                 self._board[i][column]["value"] += 1
 
                 if tile_is_empty(i, column):
-                    self._board[i][column]["id"] = "k"
+                    self._board[i][column]["id"] = "killzone"
                     self._board[i][column]["asset"] = self._killzone_asset
         
         # quadrant 1 (upper right)
@@ -71,7 +71,7 @@ class EightQueens():
             self._board[row-i][column+i]["value"] += 1
 
             if tile_is_empty(row-i, column+i):
-                self._board[row-i][column+i]["id"] = "k"
+                self._board[row-i][column+i]["id"] = "killzone"
                 self._board[row-i][column+i]["asset"] = self._killzone_asset
             i += 1
 
@@ -81,7 +81,7 @@ class EightQueens():
             self._board[row-i][column-i]["value"] += 1
 
             if tile_is_empty(row-i, column-i):
-                self._board[row-i][column-i]["id"] = "k"    
+                self._board[row-i][column-i]["id"] = "killzone"    
                 self._board[row-i][column-i]["asset"] = self._killzone_asset
             i += 1
 
@@ -91,7 +91,7 @@ class EightQueens():
             self._board[row+i][column-i]["value"] += 1
 
             if tile_is_empty(row+i, column-i):
-                self._board[row+i][column-i]["id"] = "k"
+                self._board[row+i][column-i]["id"] = "killzone"
                 self._board[row+i][column-i]["asset"] = self._killzone_asset
             i += 1
 
@@ -101,7 +101,7 @@ class EightQueens():
             self._board[row+i][column+i]["value"] += 1
 
             if tile_is_empty(row+i, column+i):
-                self._board[row+i][column+i]["id"] = "k"
+                self._board[row+i][column+i]["id"] = "killzone"
                 self._board[row+i][column+i]["asset"] = self._killzone_asset
             i += 1
 
@@ -116,7 +116,7 @@ class EightQueens():
 
         removed_queen_was_killzone = self._board[row][column]["value"] > 0
         if removed_queen_was_killzone:
-            self._board[row][column]["id"] = "k"
+            self._board[row][column]["id"] = "killzone"
 
         def removed_killzone_is_empty(row: int, column: int) -> bool:
             'helper subfunction to avoid replacing asset of an invalid queen when removing a killzone'

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -1,18 +1,23 @@
 from pathlib import Path
 
 class EightQueens():
-    """
-    !REMOVE THIS!
-    structure:
-        1. properties first
-        2. public methods next
-        3. private methods last
-    """
+    'description'
 
     def __init__(self, size: int = 8):
         self._size = size
         self._queen_positions = []
         self._board = [[{}]]
+        """ temporary _generate_board for testing
+        self._board = [[{
+            "id": None,
+            "value": 0,
+            "asset": None
+        } for _ in range(8)] for _ in range(8)]
+        """
+        self._valid_queen_asset = Path("path/to/valid/queen/asset")
+        self._invalid_queen_asset = Path("path/to/invalid/queen/asset")
+        self._killzone_asset = Path("path/to/killzone/asset")
+
         self._generate_board()
     
     @property
@@ -29,12 +34,62 @@ class EightQueens():
     def queens(self) -> list[tuple[int,int]]:
         return self._queen_positions
     
-    def add_queen(self, position: tuple[int,int]):
-        self._validate_position(position)
-        self._queen_positions.append(position)
-    
     def place_queen(self, position: tuple):
         self._validate_position(position)
+        self._queen_positions.append(position)
+
+        row, column = position
+        self._board[row][column]["id"] = "q"
+
+        # row and column killzone
+        for i in range(self.size):
+            # rows
+            placed_queen = column
+            if i != placed_queen:
+                self._board[row][i]["id"] = "k"
+                self._board[row][i]["value"] += 1
+                self._board[row][i]["asset"] = self._killzone_asset
+
+            # columns
+            placed_queen = row
+            if i != placed_queen:
+                self._board[i][column]["id"] = "k"
+                self._board[i][column]["value"] += 1
+                self._board[i][column]["asset"] = self._killzone_asset
+        
+        # quadrant 1 (upper right)
+        i=1
+        while row-i>=0 and column+i<self.size:
+            self._board[row-i][column+i]["id"] = "k"
+            self._board[row-i][column+i]["value"] += 1
+            self._board[row-i][column+i]["asset"] = self._killzone_asset
+            i += 1
+
+        # quadrant 2 (upper left)
+        i=1
+        while row-i>=0 and column-i>=0:
+            self._board[row-i][column-i]["id"] = "k"
+            self._board[row-i][column-i]["value"] += 1
+            self._board[row-i][column-i]["asset"] = self._killzone_asset
+            i += 1
+
+        # quadrant 3 (bottom right)
+        i=1
+        while row+i<self.size and column-i>=0:
+            self._board[row+i][column-i]["id"] = "k"
+            self._board[row+i][column-i]["value"] += 1
+            self._board[row+i][column-i]["asset"] = self._killzone_asset
+            i += 1
+
+        # quadrant 4 (bottom left)
+        i=1
+        while row+i<self.size and column+i<self.size:
+            self._board[row+i][column+i]["id"] = "k"
+            self._board[row+i][column+i]["value"] += 1
+            self._board[row+i][column+i]["asset"] = self._killzone_asset
+            i += 1
+
+        self._validate_queens()
 
     def remove_queen(self, position: tuple):
         self._validate_position(position)

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -35,7 +35,22 @@ class EightQueens():
         return self._queen_positions
     
     def place_queen(self, position: tuple):
+        """
+        Places a queen and their respective killzones on the board.
+        Killzones can overlap and queens can be placed on killzones
+
+        Args:
+            position (tuple): row and column where the queen should be placed.
+        Raises:
+            ValueError: If the specified position is already occupied by another queen.
+        """
         self._validate_position(position)
+        
+        occupied = self._board[row][column]["id"] == "queen"
+        if occupied:
+            ALREADY_OCCUPIED = f"This tile ({row},{column}) already has a queen. It has {self._board[row][column]['id']} as the id\nDid you mean to use 'remove_queen()' instead?"
+            raise ValueError(ALREADY_OCCUPIED)
+        
         self._queen_positions.append(position)
 
         row, column = position
@@ -108,7 +123,22 @@ class EightQueens():
         self._validate_queens()
 
     def remove_queen(self, position: tuple):
+        """
+        Removes a queen and their respective killzones on the board.
+        Removed killzones that overlapped with other killzones won't remove those other killzones
+
+        Args:
+            position (tuple): row and column of the queen to be removed.
+        Raises:
+            ValueError: If the specified position is not occupied by a queen.
+        """
         self._validate_position(position)
+        
+        occupied = self._board[row][column]["id"] == "queen"
+        if not occupied:
+            EMPTY_TILE = f"This tile ({row},{column}) does not have a queen. It has {self._board[row][column]['id']} as the id\nDid you mean to use 'place_queen()' instead?"
+            raise ValueError(EMPTY_TILE)
+        
         self._queen_positions.pop(self._queen_positions.index(position))
 
         row, column = position

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -45,79 +45,67 @@ class EightQueens():
             ValueError: If the specified position is already occupied by another queen.
         """
         self._validate_position(position)
-        
+        row, column = position
+
         occupied = self._board[row][column]["id"] == "queen"
         if occupied:
             ALREADY_OCCUPIED = f"This tile ({row},{column}) already has a queen. It has {self._board[row][column]['id']} as the id\nDid you mean to use 'remove_queen()' instead?"
             raise ValueError(ALREADY_OCCUPIED)
         
         self._queen_positions.append(position)
-
-        row, column = position
         self._board[row][column]["id"] = "queen"
 
-        def tile_is_empty(row: int, column: int) -> bool:
-            "helper subfunction to avoid replacing a queen's id with a killzone from other queens"
-            return self._board[row][column]["id"] != "queen"
+        def add_killzone(row: int, column: int):
+            '''
+            helper subfunction to add a killzone based on position given
+            also checks if tile is empty beforehand to avoid replacing a queen's id with a killzone from other queens
+            '''
+            is_tile_empty = self._board[row][column]["id"] != "queen"
+            if is_tile_empty:
+                self._board[row][column]["id"] = "killzone"
+                self._board[row][column]["asset"] = self._killzone_asset
+
 
         # row and column killzone
         for i in range(self.size):
+            self._board[row][i]["value"] += 1
+
             # rows
             placed_queen = column
             if i != placed_queen:
-                self._board[row][i]["value"] += 1
-
-                if tile_is_empty(row, i):
-                    self._board[row][i]["id"] = "killzone"
-                    self._board[row][i]["asset"] = self._killzone_asset
+                add_killzone(row, i)
 
             # columns
             placed_queen = row
             if i != placed_queen:
-                self._board[i][column]["value"] += 1
-
-                if tile_is_empty(i, column):
-                    self._board[i][column]["id"] = "killzone"
-                    self._board[i][column]["asset"] = self._killzone_asset
+                add_killzone(i, column)
         
         # quadrant 1 (upper right)
         i=1
         while row-i>=0 and column+i<self.size:
             self._board[row-i][column+i]["value"] += 1
-
-            if tile_is_empty(row-i, column+i):
-                self._board[row-i][column+i]["id"] = "killzone"
-                self._board[row-i][column+i]["asset"] = self._killzone_asset
+            add_killzone(row-i, column+i)
             i += 1
 
         # quadrant 2 (upper left)
         i=1
         while row-i>=0 and column-i>=0:
             self._board[row-i][column-i]["value"] += 1
-
-            if tile_is_empty(row-i, column-i):
-                self._board[row-i][column-i]["id"] = "killzone"    
-                self._board[row-i][column-i]["asset"] = self._killzone_asset
+            add_killzone(row-i, column-i)
             i += 1
 
         # quadrant 3 (bottom right)
         i=1
         while row+i<self.size and column-i>=0:
             self._board[row+i][column-i]["value"] += 1
-
-            if tile_is_empty(row+i, column-i):
-                self._board[row+i][column-i]["id"] = "killzone"
-                self._board[row+i][column-i]["asset"] = self._killzone_asset
+            add_killzone(row+i, column-i)
             i += 1
 
         # quadrant 4 (bottom left)
         i=1
         while row+i<self.size and column+i<self.size:
             self._board[row+i][column+i]["value"] += 1
-
-            if tile_is_empty(row+i, column+i):
-                self._board[row+i][column+i]["id"] = "killzone"
-                self._board[row+i][column+i]["asset"] = self._killzone_asset
+            add_killzone(row+i, column+i)
             i += 1
 
         self._validate_queens()
@@ -133,6 +121,7 @@ class EightQueens():
             ValueError: If the specified position is not occupied by a queen.
         """
         self._validate_position(position)
+        row, column = position
         
         occupied = self._board[row][column]["id"] == "queen"
         if not occupied:
@@ -141,75 +130,62 @@ class EightQueens():
         
         self._queen_positions.pop(self._queen_positions.index(position))
 
-        row, column = position
         self._board[row][column]["id"] = None
 
         removed_queen_was_killzone = self._board[row][column]["value"] > 0
         if removed_queen_was_killzone:
             self._board[row][column]["id"] = "killzone"
 
-        def removed_killzone_is_empty(row: int, column: int) -> bool:
-            'helper subfunction to avoid replacing asset of an invalid queen when removing a killzone'
-            return self._board[row][column]["value"] == 0 and self._board[row][column]["asset"] == self._killzone_asset
+        def remove_killzone(row: int, column: int):
+            '''
+            helper subfunction to remove a killzone based on position given
+            also to avoid replacing asset of an invalid queen when removing a killzone
+            '''
+            is_removed_killzone_empty = self._board[row][column]["value"] == 0 and self._board[row][column]["asset"] == self._killzone_asset
+            if is_removed_killzone_empty:
+                self._board[row][column]["id"] = None
+                self._board[row][column]["asset"] = None
 
         # row and column killzone
         for i in range(self.size):
+            self._board[row][i]["value"] -= 1
+
             # rows
             removed_queen = column
             if i != removed_queen:
-                self._board[row][i]["value"] -= 1
-
-                if removed_killzone_is_empty(row, i):
-                    self._board[row][i]["id"] = None
-                    self._board[row][i]["asset"] = None
+                remove_killzone(row, i)
 
             # columns
             removed_queen = row
             if i != removed_queen:
-                self._board[i][column]["value"] -= 1
-
-                if removed_killzone_is_empty(i,column):
-                    self._board[i][column]["id"] = None
-                    self._board[i][column]["asset"] = None
+                remove_killzone(i, column)
         
         # quadrant 1 (upper right)
         i=1
         while row-i>=0 and column+i<self.size:
             self._board[row-i][column+i]["value"] -= 1
-
-            if removed_killzone_is_empty(row-i, column+i):
-                self._board[row-i][column+i]["id"] = None
-                self._board[row-i][column+i]["asset"] = None
+            remove_killzone(row-i, column+i)
             i += 1
 
         # quadrant 2 (upper left)
         i=1
         while row-i>=0 and column-i>=0:
             self._board[row-i][column-i]["value"] -= 1
-            
-            if removed_killzone_is_empty(row-i, column-i):
-                self._board[row-i][column-i]["id"] = None
-                self._board[row-i][column-i]["asset"] = None
+            remove_killzone(row-i, column-i)
             i += 1
 
         # quadrant 3 (bottom right)
         i=1
         while row+i<self.size and column-i>=0:
             self._board[row+i][column-i]["value"] -= 1
-            
-            if removed_killzone_is_empty(row+i, column-i):
-                self._board[row+i][column-i]["id"] = None
-                self._board[row+i][column-i]["asset"] = None
+            remove_killzone(row+i, column-i)
             i += 1
 
         # quadrant 4 (bottom left)
         i=1
         while row+i<self.size and column+i<self.size:
             self._board[row+i][column+i]["value"] -= 1
-            
-            if removed_killzone_is_empty(row+i, column+i):
-                self._board[row+i][column+i]["id"] = None
-                self._board[row+i][column+i]["asset"] = None
+            remove_killzone(row+i, column+i)
             i += 1
 
         self._validate_queens()


### PR DESCRIPTION
closes #2
___
### highlights
1. place_queen() has a helper subfunction to avoid replacing previously placed queens's id and asset
    - eg. when a placed queen's killzone has a previously placed queen in it
2. remove_queen() has a helper subfunction to avoid removing a queen's asset and id
    - eg. when a queen is in a killzone and that killzone is about to be removed
### changes
1. add_queen() method is removed since that function is only used under place_queen. seemed redundant