### PR TITLE
Generate answers

### DIFF
--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -200,8 +200,12 @@ class EightQueens():
         self._killzone_asset = Path(killzone).resolve()
 
     def generate_answers(self):
+        '''
+        generates solutions to n queens problem using recursive backtracing
+        
+        calls self.export_board() whenever a solution is found
+        '''
         def generate(row: int = 0) -> bool:
-
             # base case
             if row >= self.size:
                 return
@@ -213,7 +217,6 @@ class EightQueens():
                 tile = board_row[i]
 
                 if tile['value'] == 0:
-                    print(f"place_queen({row}, {i})")
                     self.place_queen(row, i)
                     all_8_queens_valid = self._validate_queens() and len(self.queens) == 8
 
@@ -223,7 +226,6 @@ class EightQueens():
                     generate(row+1)
                     self.remove_queen(row, i)
             
-            # return is_solution
         generate()
 
     def export_board(self):

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 class EightQueens():
     'description'
@@ -199,10 +200,49 @@ class EightQueens():
         self._killzone_asset = Path(killzone).resolve()
 
     def generate_answers(self):
-        pass
+        def generate(row: int = 0) -> bool:
+
+            # base case
+            if row >= self.size:
+                return
+            
+            board_row = self._board[row]
+            is_last_row = row == self.size - 1
+
+            for i in range(self.size):
+                tile = board_row[i]
+
+                if tile['value'] == 0:
+                    print(f"place_queen({row}, {i})")
+                    self.place_queen(row, i)
+                    all_8_queens_valid = self._validate_queens() and len(self.queens) == 8
+
+                    if is_last_row and all_8_queens_valid:
+                        self.export_board()
+                    
+                    generate(row+1)
+                    self.remove_queen(row, i)
+            
+            # return is_solution
+        generate()
 
     def export_board(self):
-        pass
+        export_path = Path(f'./boards/board_{datetime.now().strftime(r"%Y%m%d_%H%M%S%f")}.txt')
+        Path.mkdir(export_path.parent, exist_ok=True, parents=True)
+
+        with open(export_path, "w") as file:
+            for row in self.board:
+                for value in row:
+                    if value['id'] == "queen":
+                        file.write("Q\t")
+
+                    elif value['id'] == "killzone":
+                        file.write(".\t")
+
+                    else:
+                        file.write("!\t")
+
+                file.write("\n")
 
     def file_to_board(self, file: Path):
         pass

--- a/algorithm/eight_queens.py
+++ b/algorithm/eight_queens.py
@@ -32,7 +32,7 @@ class EightQueens():
         'generates a new board with blank tiles'
         self._generate_board()
 
-    def place_queen(self, position: tuple):
+    def place_queen(self, row: int, column: int):
         """
         Places a queen and their respective killzones on the board.
         Killzones can overlap and queens can be placed on killzones
@@ -42,14 +42,14 @@ class EightQueens():
         Raises:
             ValueError: If the specified position is already occupied by another queen.
         """
-        self._validate_position(position)
-        row, column = position
+        self._validate_position(row, column)
 
         occupied = self._board[row][column]["id"] == "queen"
         if occupied:
             ALREADY_OCCUPIED = f"This tile ({row},{column}) already has a queen. It has {self._board[row][column]['id']} as the id\nDid you mean to use 'remove_queen()' instead?"
             raise ValueError(ALREADY_OCCUPIED)
         
+        position = (row, column)
         self._queen_positions.append(position)
         self._board[row][column]["id"] = "queen"
 
@@ -113,7 +113,7 @@ class EightQueens():
 
         self._validate_queens()
 
-    def remove_queen(self, position: tuple):
+    def remove_queen(self, row: int, column: int):
         """
         Removes a queen and their respective killzones on the board.
         Removed killzones that overlapped with other killzones won't remove those other killzones
@@ -123,16 +123,15 @@ class EightQueens():
         Raises:
             ValueError: If the specified position is not occupied by a queen.
         """
-        self._validate_position(position)
-        row, column = position
+        self._validate_position(row, column)
         
         occupied = self._board[row][column]["id"] == "queen"
         if not occupied:
             EMPTY_TILE = f"This tile ({row},{column}) does not have a queen. It has {self._board[row][column]['id']} as the id\nDid you mean to use 'place_queen()' instead?"
             raise ValueError(EMPTY_TILE)
         
+        position = (row, column)
         self._queen_positions.pop(self._queen_positions.index(position))
-
         self._board[row][column]["id"] = None
 
         removed_queen_was_killzone = self._board[row][column]["value"] > 0
@@ -217,15 +216,13 @@ class EightQueens():
             } for _ in range(8)
         ] for _ in range(8)]
     
-    def _validate_position(self, position: tuple[int,int]):
+    def _validate_position(self, row: int, column: int):
         'interrupt process if not a valid position'
-        tuple_of_2_ints = (
-            isinstance(position, tuple) and
-            len(position) == 2 and
-            all([isinstance(value, int) for value in position])
-        )
-        if not tuple_of_2_ints:
-            raise ValueError("Position should be a tuple of 2 ints (position in x and y)")
+        position = (row, column)
+
+        all_int = all([isinstance(value, int) for value in position])
+        if not all_int:
+            raise ValueError("Position should be 2 ints (position in x and y)")
 
         out_of_bounds = all(value > self.size for value in position)
         if out_of_bounds:


### PR DESCRIPTION
closes #5 

### highlights
1. generate solutions using recursive backtracing
2. exported text files (total of 92) look like this
```
. . Q .
Q . . .
. . . Q
. Q . .
```
3. `place_queen` and `remove_queen` take in two ints `(row, column)` instead of a tuple of two ints `((row, column))`
    - validate position is adjusted because of this change